### PR TITLE
Added RawExitPolicy to preserve accept/reject order

### DIFF
--- a/descriptor.go
+++ b/descriptor.go
@@ -76,10 +76,12 @@ type RouterDescriptor struct {
 	NTorOnionKey string
 	SigningKey   string
 
-	RawAccept string
-	RawReject string
-	Accept    []*ExitPattern
-	Reject    []*ExitPattern
+	RawAccept     string
+	RawReject     string
+	RawExitPolicy string
+
+	Accept []*ExitPattern
+	Reject []*ExitPattern
 }
 
 type RouterDescriptors struct {
@@ -320,9 +322,11 @@ func ParseRawDescriptor(rawDescriptor string) (Fingerprint, GetDescriptor, error
 
 		case "reject":
 			descriptor.RawReject += words[1] + " "
+			descriptor.RawExitPolicy += words[0] + " " + words[1] + "\n"
 
 		case "accept":
 			descriptor.RawAccept += words[1] + " "
+			descriptor.RawExitPolicy += words[0] + " " + words[1] + "\n"
 		}
 	}
 


### PR DESCRIPTION
Saw the open issue; saw a fix from @dmgawel in his fork

https://github.com/dmgawel/zoossh/commit/72fc4c9b480f527ea1332c3a3b5c60a78767e9d5

Also, it appears Accept []*ExitPattern and Reject []*ExitPattern are not being used? Unless I missed something? Looking at that as well.