### PR TITLE
Don't fail for the last relay on the status

### DIFF
--- a/consensus.go
+++ b/consensus.go
@@ -27,8 +27,6 @@ var bridgeNetworkStatusAnnotations = map[Annotation]bool{
 	Annotation{"bridge-network-status", "1", "2"}: true,
 }
 
-var ErrNoStatusEntry = fmt.Errorf("cannot find the end of status entry: \"\\nr \" or \"directory-signature\"")
-
 type GetStatus func() *RouterStatus
 
 type RouterFlags struct {
@@ -481,7 +479,7 @@ func extractStatusEntry(data []byte, atEOF bool) (advance int, token []byte, err
 		return start + end, data[start : start+end], bufio.ErrFinalToken
 	}
 	if atEOF {
-		return len(data), data[start:], ErrNoStatusEntry
+		return len(data[start:]), data[start:], bufio.ErrFinalToken
 	}
 	// Request more data.
 	return 0, nil, nil
@@ -622,7 +620,7 @@ func parseConsensusUnchecked(r io.Reader, lazy bool, strict bool) (*Consensus, e
 	// Parse incoming router statuses until the channel is closed by the remote
 	// end.
 	for unit := range queue {
-		if unit.Err != nil && (strict || !errors.Is(unit.Err, ErrNoStatusEntry)) {
+		if unit.Err != nil && strict {
 			return nil, unit.Err
 		}
 


### PR DESCRIPTION
The bridge authority doesn't add the "directory-signature" at the end of the file. The scanner function was returning an error when an EOF was reached and no "directory-signature" is there making the scanner drop the last relay from the file.

Let's return bufio.ErrFinalToken instead, so the scanner doesn't drop that record.